### PR TITLE
Add set of event queue composition functions

### DIFF
--- a/equeue.c
+++ b/equeue.c
@@ -39,6 +39,10 @@ int equeue_create_inplace(equeue_t *q, size_t size, void *buffer) {
     q->generation = 0;
     q->breaks = 0;
 
+    q->background.active = false;
+    q->background.update = 0;
+    q->background.timer = 0;
+
     int err;
     err = equeue_sema_create(&q->eventsema);
     if (err < 0) {
@@ -66,6 +70,10 @@ void equeue_destroy(equeue_t *q) {
                 e->dtor(e + 1);
             }
         }
+    }
+
+    if (q->background.update) {
+        q->background.update(q->background.timer, -1);
     }
 
     equeue_mutex_destroy(&q->memlock);
@@ -199,6 +207,11 @@ static int equeue_enqueue(equeue_t *q, struct equeue_event *e, unsigned ms) {
     *p = e;
     e->ref = p;
 
+    if ((q->background.update && q->background.active) &&
+        (q->queue == e && !e->sibling)) {
+        q->background.update(q->background.timer, ms);
+    }
+
     equeue_mutex_unlock(&q->queuelock);
 
     return id;
@@ -312,6 +325,7 @@ void equeue_break(equeue_t *q) {
 void equeue_dispatch(equeue_t *q, int ms) {
     unsigned tick = equeue_tick();
     unsigned timeout = tick + ms;
+    q->background.active = false;
 
     while (1) {
         // collect all the available events and next deadline
@@ -344,6 +358,16 @@ void equeue_dispatch(equeue_t *q, int ms) {
         if (ms >= 0) {
             deadline = equeue_tickdiff(timeout, tick);
             if (deadline <= 0) {
+                // update background timer if necessary
+                if (q->background.update) {
+                    equeue_mutex_lock(&q->queuelock);
+                    if (q->background.update && q->queue) {
+                        q->background.update(q->background.timer,
+                                equeue_tickdiff(q->queue->target, tick));
+                    }
+                    q->background.active = true;
+                    equeue_mutex_unlock(&q->queuelock);
+                }
                 return;
             }
         }
@@ -440,4 +464,23 @@ int equeue_call_every(equeue_t *q, int ms, void (*cb)(void*), void *data) {
     e->cb = cb;
     e->data = data;
     return equeue_post(q, ecallback_dispatch, e);
+}
+
+// backgrounding
+void equeue_background(equeue_t *q,
+        void (*update)(void *timer, int ms), void *timer) {
+    equeue_mutex_lock(&q->queuelock);
+    if (q->background.update) {
+        q->background.update(q->background.timer, -1);
+    }
+
+    q->background.update = update;
+    q->background.timer = timer;
+
+    if (q->background.update && q->queue) {
+        q->background.update(q->background.timer,
+                equeue_tickdiff(q->queue->target, equeue_tick()));
+    }
+    q->background.active = true;
+    equeue_mutex_unlock(&q->queuelock);
 }

--- a/equeue.h
+++ b/equeue.h
@@ -146,9 +146,18 @@ void equeue_cancel(equeue_t *queue, int event);
 //
 // The provided update function will be called to indicate when the queue
 // should be dispatched. A negative timeout will be passed to the update
-// function when the timer is no longer needed.
+// function when the timer is no longer needed. A null update function
+// will disable the existing timer.
 void equeue_background(equeue_t *queue,
         void (*update)(void *timer, int ms), void *timer);
+
+// Chain an event queue onto another event queue
+//
+// After chaining a queue to a target, calling equeue_dispatch on the
+// target queue will also dispatch events from this queue. The queues
+// will use their own buffers and events are handled independently.
+// A null queue as the target will unchain this queue.
+void equeue_chain(equeue_t *queue, equeue_t *target);
 
 
 #ifdef __cplusplus

--- a/equeue.h
+++ b/equeue.h
@@ -58,6 +58,12 @@ typedef struct equeue {
         unsigned char *data;
     } slab;
 
+    struct equeue_background {
+        bool active;
+        void (*update)(void *timer, int ms);
+        void *timer;
+    } background;
+
     equeue_sema_t eventsema;
     equeue_mutex_t queuelock;
     equeue_mutex_t memlock;
@@ -135,6 +141,14 @@ int equeue_post(equeue_t *queue, void (*cb)(void *), void *event);
 // been dispatched or does not exist, no error occurs. Note, this can not
 // stop a currently executing event
 void equeue_cancel(equeue_t *queue, int event);
+
+// Background an event queue onto a single-shot timer
+//
+// The provided update function will be called to indicate when the queue
+// should be dispatched. A negative timeout will be passed to the update
+// function when the timer is no longer needed.
+void equeue_background(equeue_t *queue,
+        void (*update)(void *timer, int ms), void *timer);
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
Adds two new composition functions for composing multiple event queues:
- `equeue_background` - The equeue_background function requires only a user-provided update function, which is called to indicate when the queue should be dispatched.
- `equeue_chain` - The equeue_chain function chains one queue onto a target queue. Calling equeue_dispatch on the target queue will also dispatch events on the target, however each queue uses their own buffers and events are handled independently.

These two functions add a new level of composability to the event queue library. Events queues can be easily backgrounded on hardware timers, or even combined with existing event loops. Multiple, independent event queues can be combined to easily share a single thread of execution between module boundaries. These functions should add significant flexibility to how a user's system can be architected.